### PR TITLE
refactor: covert payload to a model of PayloadInner.

### DIFF
--- a/src/common/remote/conn.rs
+++ b/src/common/remote/conn.rs
@@ -225,10 +225,10 @@ mod tests {
         let mut remote_connect =
             Connection::new(ClientConfig::new().server_addr("0.0.0.0:9848".to_string()));
         let server_req_payload = remote_connect.next_server_req_payload().await;
-        let (type_url, headers, body_json_str) = payload_helper::covert_payload(server_req_payload);
-        if TYPE_CLIENT_DETECTION_SERVER_REQUEST.eq(&type_url) {
-            let de = ClientDetectionServerRequest::from(body_json_str.as_str());
-            let de = de.headers(headers);
+        let payload_inner = payload_helper::covert_payload(server_req_payload);
+        if TYPE_CLIENT_DETECTION_SERVER_REQUEST.eq(&payload_inner.type_url) {
+            let de = ClientDetectionServerRequest::from(payload_inner.body_str.as_str());
+            let de = de.headers(payload_inner.headers);
             remote_connect
                 .reply_client_resp(ClientDetectionClientResponse::new(
                     de.get_request_id().clone(),

--- a/src/common/remote/conn.rs
+++ b/src/common/remote/conn.rs
@@ -13,6 +13,7 @@ use crate::common::remote::request::client_request::{
 };
 use crate::common::remote::request::Request;
 use crate::common::remote::response::Response;
+use crate::common::util::payload_helper::PayloadInner;
 use crate::common::util::*;
 use crate::nacos_proto::v2::{BiRequestStreamClient, Payload, RequestClient};
 
@@ -171,12 +172,12 @@ impl Connection {
     pub(crate) async fn send_client_req(
         &mut self,
         req: impl Request + serde::Serialize,
-    ) -> crate::api::error::Result<Box<Payload>> {
+    ) -> crate::api::error::Result<Box<PayloadInner>> {
         match self.state {
             State::Connected { ref mut client, .. } => {
                 let req_payload = payload_helper::build_req_grpc_payload(req);
                 let resp_payload = client.request(&req_payload)?;
-                Ok(Box::new(resp_payload))
+                Ok(Box::new(payload_helper::covert_payload(resp_payload)))
             }
             State::Disconnected(_) => {
                 self.connect().await;

--- a/src/common/util/payload_helper.rs
+++ b/src/common/util/payload_helper.rs
@@ -118,6 +118,7 @@ pub(crate) fn covert_payload(payload: Payload) -> PayloadInner {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use crate::common::remote::request::client_request::ServerCheckClientRequest;
     use crate::common::remote::request::Request;
     use crate::common::remote::response::server_response::ServerCheckServerResponse;
@@ -169,5 +170,6 @@ mod tests {
         println!("test_covert_payload2, type_url {}", &payload_inner.type_url);
         assert_eq!(req_type_url, payload_inner.type_url);
         assert_eq!(data, payload_inner.body_str.as_str());
+        assert_eq!(HashMap::new(), payload_inner.headers);
     }
 }

--- a/src/common/util/payload_helper.rs
+++ b/src/common/util/payload_helper.rs
@@ -6,6 +6,16 @@ use crate::nacos_proto::v2::{Metadata, Payload};
 use serde::Serialize;
 use std::collections::HashMap;
 
+/// Payload Inner Model
+pub(crate) struct PayloadInner {
+    /// The data type of `body_str`
+    pub(crate) type_url: String,
+    /// Headers
+    pub(crate) headers: HashMap<String, String>,
+    /// json data
+    pub(crate) body_str: String,
+}
+
 pub(crate) fn build_req_grpc_payload(req: impl Request + Serialize) -> Payload {
     tracing::debug!(
         "build_req_grpc_payload {} request_id={}",
@@ -91,15 +101,19 @@ pub(crate) fn build_server_request(
     Err(crate::api::error::Error::Deserialization(type_url))
 }
 
-/// (type_url, headers, body_str)
-pub(crate) fn covert_payload(payload: Payload) -> (String, HashMap<String, String>, String) {
+/// Covert payload to PayloadInner {type_url, headers, body_str}
+pub(crate) fn covert_payload(payload: Payload) -> PayloadInner {
     let metadata = payload.metadata.unwrap();
     let body_data = payload.body.unwrap().value;
     let type_url = metadata.r#type;
     let headers = metadata.headers;
     let body_str = String::from_utf8(body_data).unwrap();
     tracing::debug!("covert_payload {} with {}", type_url, body_str);
-    return (type_url, headers, body_str);
+    PayloadInner {
+        type_url,
+        headers,
+        body_str,
+    }
 }
 
 #[cfg(test)]

--- a/src/common/util/payload_helper.rs
+++ b/src/common/util/payload_helper.rs
@@ -118,8 +118,11 @@ pub(crate) fn covert_payload(payload: Payload) -> PayloadInner {
 
 #[cfg(test)]
 mod tests {
+    use crate::common::remote::request::client_request::ServerCheckClientRequest;
+    use crate::common::remote::request::Request;
     use crate::common::remote::response::server_response::ServerCheckServerResponse;
     use crate::common::remote::response::Response;
+    use crate::common::util::payload_helper;
 
     #[test]
     fn it_works_serde_json() {
@@ -133,5 +136,38 @@ mod tests {
         let resp: ServerCheckServerResponse = serde_json::from_str(data).unwrap();
         println!("serde_json resp {:?}", resp);
         assert_eq!(resp.get_request_id().unwrap().as_str(), "666");
+    }
+
+    #[test]
+    fn test_covert_payload1() {
+        let data = r#"
+        {
+            "connectionId": "uuid",
+            "requestId": "666",
+            "resultCode": 200,
+            "errorCode": 0
+        }"#;
+        let resp: ServerCheckServerResponse = serde_json::from_str(data).unwrap();
+        let resp_type_url = resp.get_type_url().to_string();
+
+        let payload = payload_helper::build_resp_grpc_payload(resp);
+        let payload_inner = payload_helper::covert_payload(payload);
+
+        println!("test_covert_payload1, type_url {}", &payload_inner.type_url);
+        assert_eq!(resp_type_url, payload_inner.type_url);
+    }
+
+    #[test]
+    fn test_covert_payload2() {
+        let data = "{\"requestId\":\"666\",\"headers\":{}}";
+        let req: ServerCheckClientRequest = serde_json::from_str(data).unwrap();
+        let req_type_url = req.get_type_url().to_string();
+
+        let payload = payload_helper::build_req_grpc_payload(req);
+        let payload_inner = payload_helper::covert_payload(payload);
+
+        println!("test_covert_payload2, type_url {}", &payload_inner.type_url);
+        assert_eq!(req_type_url, payload_inner.type_url);
+        assert_eq!(data, payload_inner.body_str.as_str());
     }
 }


### PR DESCRIPTION
PayloadInner replace (type_url, headers, body_json_str).
使用 PayloadInner 模型替代三元组。